### PR TITLE
Make Default LDAP attributes overridable by additional attributes

### DIFF
--- a/www/includes/ldap_functions.inc.php
+++ b/www/includes/ldap_functions.inc.php
@@ -782,10 +782,13 @@ function ldap_new_account($ldap_connection,$account_r) {
                                 'userPassword' => $hashed_pass,
                       );
 
-    unset($account_r['password']);
-    $account_attributes = array_merge($account_attributes, $account_r);
-
-    $add_account = @ ldap_add($ldap_connection,
+   unset($account_r['password']);
+   $account_attributes = array_change_key_case($account_attributes, CASE_LOWER);
+   $account_r = array_change_key_case($account_r, CASE_LOWER);
+   $account_attributes = array_replace_recursive($account_attributes, $account_r);
+   
+   
+   $add_account = @ ldap_add($ldap_connection,
                               "${LDAP['account_attribute']}=$account_identifier,${LDAP['user_dn']}",
                               $account_attributes
                              );


### PR DESCRIPTION
This request is designed to allow attributes specified in 'LDAP_ADDITIONAL_ATTRIBUTES' to override the default attributes.

For example, if you put 'uidnumber' in additional attributes, then instead of using LastUID+1 it will allow you to manually enter a UID number. 
This also allows you to re-label fields (eg, make the uid field into 'UNIX Username' by defining it as such in additional attributes)

It does not address the cn=lastUID being incremented, but logically an org that is manually assigning UIDs won't be relying on that anyway (Eg, they are using HR assigned badge-numbers as UNIX UIDs, so a manually entered UID will always be unique). 

Mechanisim is as follows:
1) Force both array's keys (but not values) to lowercase
2) Use array_replace_recursive instead of array_merge, to overwrite the 'default' array's key-value pairs with those of the additional_attributes array.